### PR TITLE
Make accidentals consistent

### DIFF
--- a/src/components/Fretboard/String/index.tsx
+++ b/src/components/Fretboard/String/index.tsx
@@ -5,6 +5,7 @@ import { note, transpose, distance, interval } from '@tonaljs/tonal';
 import { fromSemitones } from '@tonaljs/interval';
 
 import Fret from '../Fret';
+import simplifyNoteName from '../../../lib/simplifyNoteName';
 
 const FlexRow = styled.div`
     display: flex;
@@ -64,7 +65,7 @@ const String: React.FC<StringProps> = ( { letter, octave, renderLabel, frets, ro
                     >  
                         { label && renderLabel ? 
                             renderLabel( { label } ) 
-                            : transposedNote.pc
+                            : simplifyNoteName( transposedNote.pc, '#' )
                         }
                     </Fret>
                 );

--- a/src/components/IntervalStrip/index.tsx
+++ b/src/components/IntervalStrip/index.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { includes } from 'lodash';
 import * as Tonal from '@tonaljs/tonal';
-import { simplify } from '@tonaljs/interval';
+
+import simplifyNoteName from '../../lib/simplifyNoteName';
 
 const Container = styled.div`
     display: flex;
@@ -72,7 +73,7 @@ interface IntervalStripProps {
     activeIntervals?: string[];
 }
 
-const ChordInformation: React.FC<IntervalStripProps> = ( { root, activeIntervals } ) => {
+const IntervalStrip: React.FC<IntervalStripProps> = ( { root, activeIntervals } ) => {
     const activeSemitones = activeIntervals.map( interval => Tonal.interval( interval ).semitones )
 
     return (
@@ -82,16 +83,13 @@ const ChordInformation: React.FC<IntervalStripProps> = ( { root, activeIntervals
                     interval => { 
                         const semitones = Tonal.interval( interval ).semitones;
                         const color = getRelativeChromaticColor( semitones % 12 );
-
                         const note = Tonal.transpose( root, interval ); 
-
                         const isActive = includes( activeSemitones, semitones );
-
-                        const intervalLabel = interval.replace( '1P', 'Root' )
+                        const intervalLabel = interval.replace( '1P', 'Root' );
 
                         return (
                             <FlexColumn isActive={ isActive }>
-                                <Note color={ color }>{ note }</Note>
+                                <Note color={ color }>{ simplifyNoteName( note, '#' ) }</Note>
                                 <Note color={ color }>{ intervalLabel }</Note>
                             </FlexColumn>
                         );
@@ -101,4 +99,4 @@ const ChordInformation: React.FC<IntervalStripProps> = ( { root, activeIntervals
         </Container>
     );
 }
-export default ChordInformation;
+export default IntervalStrip;

--- a/src/components/OptionSelection/OptionButton.tsx
+++ b/src/components/OptionSelection/OptionButton.tsx
@@ -11,6 +11,7 @@ const OptionButton = styled.button<OptionButtonProps>`
     border: 2px solid rgba( 255, 255, 255, 0.4 );
     flex-grow: 1;
     cursor: pointer;
+    text-transform: capitalize;
 
     &:hover {
         background: ${ props => props.isSelected ? '#67E5D2' : '#eee'  };

--- a/src/containers/ChordSelectFretboard/index.tsx
+++ b/src/containers/ChordSelectFretboard/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { startCase } from 'lodash';
 import * as Tonal from '@tonaljs/tonal';
 import { chord } from '@tonaljs/chord';
 
@@ -8,6 +7,7 @@ import chromaticNotes from '../../constants/chromaticNotes';
 import FretBoard from '../../components/Fretboard';
 import OptionSelection from '../../components/OptionSelection';
 import IntervalStrip from '../../components/IntervalStrip';
+import simplifyNoteName from '../../lib/simplifyNoteName';
 
 const Container = styled.div`
     max-width: 960px;   
@@ -18,6 +18,7 @@ const Container = styled.div`
 const Heading = styled.h2`
     font-size: 2em;
     color: white;
+    text-transform: capitalize;
 `;
 
 const Controls = styled.div`
@@ -39,10 +40,9 @@ const commonChordTypes = [
 ]
 
 const rootOptions = chromaticNotes.map( x => ( { value: x, label: x } ) );
-const chordOptions = commonChordTypes.map( x => ( { value: x, label: startCase( x ) } ) );
+const chordOptions = commonChordTypes.map( x => ( { value: x, label: x } ) );
 
-// TODO: This feels unclear, needs improvement.
-const getItemsInScale = ( root, chordType ) => {
+const getChordLabels = ( root, chordType ) => {
     const { intervals, notes } = chord( `${ root }${ chordType }` );
 
     return intervals.map(
@@ -50,7 +50,7 @@ const getItemsInScale = ( root, chordType ) => {
             {
                 semitones: Tonal.interval( interval ).semitones,
                 interval,
-                note: notes[ index ],
+                note: simplifyNoteName( notes[ index ], '#' ),
             }
         )
     );
@@ -59,8 +59,9 @@ const getItemsInScale = ( root, chordType ) => {
 const ScaleSelectFretboard: React.FC<{}> = () => {
     const [ root, setRoot ] = React.useState( rootOptions[ 0 ].value );
     const [ chordType, setChordType ] = React.useState( chordOptions[ 0 ].value );
-    const labels = getItemsInScale( root, chordType );
-    const { intervals, notes, name  } = chord( `${ root }${ chordType }` );
+    const labels = getChordLabels( root, chordType );
+    const chordData = chord( `${ root }${ chordType }` );
+    const { intervals, name  } = chordData;
 
     return (
         <Container>
@@ -68,7 +69,7 @@ const ScaleSelectFretboard: React.FC<{}> = () => {
                 <OptionSelection
                     onSelectOption={ setRoot }
                     selectedOption={ root }
-                    options={ chromaticNotes.map( x => ( { value: x, label: x } ) ) }
+                    options={ rootOptions }
                 />
                 <OptionSelection
                     onSelectOption={ setChordType }
@@ -76,7 +77,7 @@ const ScaleSelectFretboard: React.FC<{}> = () => {
                     options={ chordOptions }
                 />
             </Controls>
-            <Heading>{ startCase( name ) }</Heading>
+            <Heading>{ name }</Heading>
             <IntervalStrip
                 root={ root }
                 activeIntervals={ intervals }

--- a/src/lib/simplifyNoteName/index.ts
+++ b/src/lib/simplifyNoteName/index.ts
@@ -1,0 +1,12 @@
+import { simplify, enharmonic } from '@tonaljs/note';
+
+type easing = 'b' | '#';
+
+// A#, # => A#
+// A, # => A
+// Bb, # => A#
+
+const simplifyNoteName = ( noteName: string, accidentaltype: easing = '#' ) =>
+    simplify( noteName.indexOf( accidentaltype ) >=1 ? noteName : enharmonic( noteName ) );
+
+export default simplifyNoteName;


### PR DESCRIPTION
This PR adds a `simplifyNoteName` utility, which accepts a flat (`b`) or a sharp (`#`). Providing either accidental type will force the note to it's enharmonic if it doesn't already match.